### PR TITLE
장바구니 API 기능 추가 및 테스트

### DIFF
--- a/src/main/java/com/jaw/cart/application/CartService.java
+++ b/src/main/java/com/jaw/cart/application/CartService.java
@@ -27,25 +27,26 @@ public class CartService {
 	private final MemberRepository memberRepository;
 
 	public CartMenu addMenu(Long memberId, Menu menu, long count) {
-		Cart cart = cartRepository.findByMemberId(memberId)
-			.orElse(create(memberId));
-
+		Cart cart = findCartByMemberId(memberId);
 		CartMenu cartMenu = new CartMenu(cart, menu, count);
 		return cartMenuRepository.save(cartMenu);
 	}
 
 	@Transactional(readOnly = true)
 	public List<CartMenuResponseDTO> findAll(Long memberId) {
-		Cart cart = cartRepository.findByMemberId(memberId)
-			.orElse(create(memberId));
-
+		Cart cart = findCartByMemberId(memberId);
 		return cartMenuRepository.findAllByCart(cart)
 			.stream()
 			.map(CartMenuResponseDTO::new)
 			.collect(Collectors.toList());
 	}
 
-	private Cart create(Long memberId) {
+	private Cart findCartByMemberId(Long memberId) {
+		return cartRepository.findByMemberId(memberId)
+			.orElseGet(() -> createNewCart(memberId));
+	}
+
+	private Cart createNewCart(Long memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(IllegalArgumentException::new);
 		return cartRepository.save(new Cart(member));

--- a/src/main/java/com/jaw/cart/application/CartService.java
+++ b/src/main/java/com/jaw/cart/application/CartService.java
@@ -1,6 +1,7 @@
 package com.jaw.cart.application;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +10,7 @@ import com.jaw.cart.domain.Cart;
 import com.jaw.cart.domain.CartMenu;
 import com.jaw.cart.domain.CartMenuRepository;
 import com.jaw.cart.domain.CartRepository;
+import com.jaw.cart.ui.CartMenuResponseDTO;
 import com.jaw.member.domain.Member;
 import com.jaw.member.domain.MemberRepository;
 import com.jaw.menu.domain.Menu;
@@ -24,12 +26,6 @@ public class CartService {
 	private final CartMenuRepository cartMenuRepository;
 	private final MemberRepository memberRepository;
 
-	public Cart create(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(IllegalArgumentException::new);
-		return cartRepository.save(new Cart(member));
-	}
-
 	public CartMenu addMenu(Long memberId, Menu menu, long count) {
 		Cart cart = cartRepository.findByMemberId(memberId)
 			.orElse(create(memberId));
@@ -39,9 +35,19 @@ public class CartService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<CartMenu> findAll(Long memberId) {
+	public List<CartMenuResponseDTO> findAll(Long memberId) {
 		Cart cart = cartRepository.findByMemberId(memberId)
 			.orElse(create(memberId));
-		return cartMenuRepository.findAllByCart(cart);
+
+		return cartMenuRepository.findAllByCart(cart)
+			.stream()
+			.map(CartMenuResponseDTO::new)
+			.collect(Collectors.toList());
+	}
+
+	private Cart create(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(IllegalArgumentException::new);
+		return cartRepository.save(new Cart(member));
 	}
 }

--- a/src/main/java/com/jaw/cart/application/CartService.java
+++ b/src/main/java/com/jaw/cart/application/CartService.java
@@ -14,6 +14,7 @@ import com.jaw.cart.ui.CartMenuResponseDTO;
 import com.jaw.member.domain.Member;
 import com.jaw.member.domain.MemberRepository;
 import com.jaw.menu.domain.Menu;
+import com.jaw.menu.domain.MenuRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,12 +25,15 @@ public class CartService {
 
 	private final CartRepository cartRepository;
 	private final CartMenuRepository cartMenuRepository;
+	private final MenuRepository menuRepository;
 	private final MemberRepository memberRepository;
 
-	public CartMenu addMenu(Long memberId, Menu menu, long count) {
+	public CartMenuResponseDTO addMenu(Long memberId, Long menuId, long count) {
 		Cart cart = findCartByMemberId(memberId);
-		CartMenu cartMenu = new CartMenu(cart, menu, count);
-		return cartMenuRepository.save(cartMenu);
+		Menu menu = menuRepository.findById(menuId)
+			.orElseThrow(IllegalArgumentException::new);
+		CartMenu cartMenu = cartMenuRepository.save(new CartMenu(cart, menu, count));
+		return new CartMenuResponseDTO(cartMenu);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/jaw/cart/domain/JpaCartMenuRepository.java
+++ b/src/main/java/com/jaw/cart/domain/JpaCartMenuRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface JpaCartMenuRepository extends CartMenuRepository, JpaRepository<CartMenu, Long> {
 
-	@Query("select cm from CartMenu cm where cm.cart = :cart")
+	@Query("select cm from CartMenu cm join fetch cm.menu where cm.cart = :cart")
 	List<CartMenu> findAllByCart(@Param("cart") Cart cart);
 }

--- a/src/main/java/com/jaw/cart/ui/CartMenuRequestDTO.java
+++ b/src/main/java/com/jaw/cart/ui/CartMenuRequestDTO.java
@@ -1,0 +1,14 @@
+package com.jaw.cart.ui;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartMenuRequestDTO {
+
+	private Long menuId;
+	private long count;
+}

--- a/src/main/java/com/jaw/cart/ui/CartMenuResponseDTO.java
+++ b/src/main/java/com/jaw/cart/ui/CartMenuResponseDTO.java
@@ -1,0 +1,20 @@
+package com.jaw.cart.ui;
+
+import com.jaw.cart.domain.CartMenu;
+import com.jaw.menu.ui.MenuResponseDTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CartMenuResponseDTO {
+
+	private MenuResponseDTO menu;
+	private long count;
+
+	public CartMenuResponseDTO(CartMenu cartMenu) {
+		this.menu = new MenuResponseDTO(cartMenu.getMenu());
+		this.count = cartMenu.getCount();
+	}
+}

--- a/src/main/java/com/jaw/cart/ui/CartMenuResponseDTO.java
+++ b/src/main/java/com/jaw/cart/ui/CartMenuResponseDTO.java
@@ -4,14 +4,12 @@ import com.jaw.cart.domain.CartMenu;
 import com.jaw.menu.ui.MenuResponseDTO;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CartMenuResponseDTO {
 
-	private MenuResponseDTO menu;
-	private long count;
+	private final MenuResponseDTO menu;
+	private final long count;
 
 	public CartMenuResponseDTO(CartMenu cartMenu) {
 		this.menu = new MenuResponseDTO(cartMenu.getMenu());

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -1,16 +1,13 @@
 package com.jaw.cart.ui;
 
-import java.net.URI;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jaw.cart.application.CartService;
-import com.jaw.cart.domain.Cart;
 import com.jaw.cart.domain.CartMenu;
 
 import lombok.RequiredArgsConstructor;
@@ -20,13 +17,6 @@ import lombok.RequiredArgsConstructor;
 public class CartRestController {
 
 	private final CartService cartService;
-
-	@PostMapping("/members/{memberId}/cart")
-	public ResponseEntity<Cart> create(@PathVariable Long memberId) {
-		Cart cart = cartService.create(memberId);
-		return ResponseEntity.created(URI.create(String.format("/members/%d/cart", memberId)))
-			.body(cart);
-	}
 
 	@GetMapping("/members/{memberId}/cart")
 	public ResponseEntity<List<CartMenu>> findAll(@PathVariable Long memberId) {

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -1,10 +1,13 @@
 package com.jaw.cart.ui;
 
+import java.net.URI;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jaw.cart.application.CartService;
@@ -20,5 +23,14 @@ public class CartRestController {
 	@GetMapping("/members/{memberId}/cart")
 	public ResponseEntity<List<CartMenuResponseDTO>> findAll(@PathVariable Long memberId) {
 		return ResponseEntity.ok(cartService.findAll(memberId));
+	}
+
+	@PostMapping("/members/{memberId}/cart")
+	public ResponseEntity<CartMenuResponseDTO> addMenu(@PathVariable Long memberId,
+													   @RequestBody CartMenuRequestDTO request) {
+
+		CartMenuResponseDTO cartMenu = cartService.addMenu(memberId, request.getMenuId(), request.getCount());
+		return ResponseEntity.created(URI.create(String.format("/members/%d/cart", memberId)))
+			.body(cartMenu);
 	}
 }

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jaw.cart.application.CartService;
-import com.jaw.cart.domain.CartMenu;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,7 +18,7 @@ public class CartRestController {
 	private final CartService cartService;
 
 	@GetMapping("/members/{memberId}/cart")
-	public ResponseEntity<List<CartMenu>> findAll(@PathVariable Long memberId) {
+	public ResponseEntity<List<CartMenuResponseDTO>> findAll(@PathVariable Long memberId) {
 		return ResponseEntity.ok(cartService.findAll(memberId));
 	}
 }

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -1,19 +1,18 @@
 package com.jaw.cart.application;
 
-import com.jaw.cart.domain.Cart;
-import com.jaw.cart.domain.CartMenu;
-import com.jaw.member.application.InMemoryMemberRepository;
-import com.jaw.member.domain.Member;
-import com.jaw.menu.domain.Menu;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.jaw.cart.ui.CartMenuResponseDTO;
+import com.jaw.member.application.InMemoryMemberRepository;
+import com.jaw.member.domain.Member;
+import com.jaw.menu.domain.Menu;
 
 class CartServiceTest {
 
@@ -37,22 +36,16 @@ class CartServiceTest {
 		memberRepository.clear();
 	}
 
-	@DisplayName("회원의 장바구니를 생성한다.")
-	@Test
-	void create() {
-		Member member = memberRepository.save(member( "홍길동"));
-		Cart cart = cartService.create(member.getId());
-		assertThat(cart.getMember()).isEqualTo(member);
-	}
-
 	@DisplayName("장바구니에 메뉴를 추가한다.")
 	@Test
-	void add() {
+	void addMenu() {
 		Member member = memberRepository.save(member("고길동"));
-		Cart cart = cartService.create(member.getId());
+
 		cartService.addMenu(member.getId(), menu("바닐라 플랫 화이트", 5_900), 1);
 		cartService.addMenu(member.getId(), menu("아이스 카페 모카", 5_500), 1);
-		List<CartMenu> cartMenus = cartMenuRepository.findAllByCart(cart);
+
+		List<CartMenuResponseDTO> cartMenus = cartService.findAll(member.getId());
+
 		assertThat(cartMenus).hasSize(2);
 	}
 

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -12,12 +12,14 @@ import org.junit.jupiter.api.Test;
 import com.jaw.cart.ui.CartMenuResponseDTO;
 import com.jaw.member.application.InMemoryMemberRepository;
 import com.jaw.member.domain.Member;
+import com.jaw.menu.application.InMemoryMenuRepository;
 import com.jaw.menu.domain.Menu;
 
 class CartServiceTest {
 
 	private InMemoryCartRepository cartRepository;
 	private InMemoryCartMenuRepository cartMenuRepository;
+	private InMemoryMenuRepository menuRepository;
 	private InMemoryMemberRepository memberRepository;
 	private CartService cartService;
 
@@ -25,8 +27,9 @@ class CartServiceTest {
 	void setup() {
 		cartRepository = new InMemoryCartRepository();
 		cartMenuRepository = new InMemoryCartMenuRepository();
+		menuRepository = new InMemoryMenuRepository();
 		memberRepository = new InMemoryMemberRepository();
-		cartService = new CartService(cartRepository, cartMenuRepository, memberRepository);
+		cartService = new CartService(cartRepository, cartMenuRepository, menuRepository, memberRepository);
 	}
 
 	@AfterEach
@@ -40,9 +43,11 @@ class CartServiceTest {
 	@Test
 	void addMenu() {
 		Member member = memberRepository.save(member("고길동"));
+		Menu vanillaFlatWhite = menuRepository.save(menu("바닐라 플랫 화이트", 5_900));
+		Menu icedCaffeMocha = menuRepository.save(menu("아이스 카페 모카", 5_500));
 
-		cartService.addMenu(member.getId(), menu("바닐라 플랫 화이트", 5_900), 1);
-		cartService.addMenu(member.getId(), menu("아이스 카페 모카", 5_500), 1);
+		cartService.addMenu(member.getId(), vanillaFlatWhite.getId(), 1);
+		cartService.addMenu(member.getId(), icedCaffeMocha.getId(), 1);
 
 		List<CartMenuResponseDTO> cartMenus = cartService.findAll(member.getId());
 

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -1,0 +1,99 @@
+package com.jaw.cart.ui;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jaw.cart.application.CartService;
+import com.jaw.cart.domain.CartMenu;
+import com.jaw.member.domain.Member;
+import com.jaw.member.domain.MemberRepository;
+import com.jaw.menu.domain.Menu;
+import com.jaw.menu.domain.MenuRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@TestPropertySource("/application-dev.properties")
+class CartRestControllerTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private MenuRepository menuRepository;
+
+	@Autowired
+	private CartService cartService;
+
+	private Member member;
+
+	@BeforeEach
+	void setup() {
+		mvc = MockMvcBuilders.webAppContextSetup(wac)
+			.addFilters(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+			.alwaysDo(print())
+			.build();
+
+		member = memberRepository.save(Member.builder()
+			.name("홍길동")
+			.nickname("hong")
+			.birthDate(LocalDate.now())
+			.email("hong@gmail.com")
+			.phoneNumber("010-1234-5678")
+			.build());
+	}
+
+	@DisplayName("장바구니에 담긴 모든 메뉴를 조회한다.")
+	@Test
+	void findAll() throws Exception {
+		Menu icedAmericano = menuRepository.save(menu("아이스 아메리카노", 4_500));
+		Menu mangoBanana = menuRepository.save(menu("망고 바나나 블렌디드", 6_300));
+
+		CartMenu icedAmericanoInCart = cartService.addMenu(member.getId(), icedAmericano, 1);
+		CartMenu mangoBananaInCart = cartService.addMenu(member.getId(), mangoBanana, 1);
+
+		List<CartMenuResponseDTO> responses = List.of(
+			new CartMenuResponseDTO(icedAmericanoInCart),
+			new CartMenuResponseDTO(mangoBananaInCart)
+		);
+
+		mvc.perform(MockMvcRequestBuilders.get("/members/{memberId}/cart", member.getId()))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(responses)));
+	}
+
+	private Menu menu(String name, long price) {
+		return Menu.builder()
+			.name(name)
+			.price(price)
+			.build();
+	}
+}

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -1,5 +1,6 @@
 package com.jaw.cart.ui;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -13,9 +14,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
@@ -23,7 +24,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jaw.cart.application.CartService;
-import com.jaw.cart.domain.CartMenu;
 import com.jaw.member.domain.Member;
 import com.jaw.member.domain.MemberRepository;
 import com.jaw.menu.domain.Menu;
@@ -71,21 +71,34 @@ class CartRestControllerTest {
 			.build());
 	}
 
+	@DisplayName("장바구니에 메뉴를 추가한다.")
+	@Test
+	void addMenu() throws Exception {
+		Menu americano = menuRepository.save(menu("아메리카노", 4_000));
+
+		CartMenuRequestDTO request = new CartMenuRequestDTO(americano.getId(), 1);
+
+		mvc.perform(post("/members/{memberId}/cart", member.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.menu.id").value(americano.getId()))
+			.andExpect(jsonPath("$.menu.name").value(americano.getName()))
+			.andExpect(jsonPath("$.menu.price").value(americano.getPrice()))
+			.andExpect(jsonPath("$.count").value(1));
+	}
+
 	@DisplayName("장바구니에 담긴 모든 메뉴를 조회한다.")
 	@Test
 	void findAll() throws Exception {
 		Menu icedAmericano = menuRepository.save(menu("아이스 아메리카노", 4_500));
 		Menu mangoBanana = menuRepository.save(menu("망고 바나나 블렌디드", 6_300));
 
-		CartMenu icedAmericanoInCart = cartService.addMenu(member.getId(), icedAmericano, 1);
-		CartMenu mangoBananaInCart = cartService.addMenu(member.getId(), mangoBanana, 1);
+		CartMenuResponseDTO icedAmericanoInCart = cartService.addMenu(member.getId(), icedAmericano.getId(), 1);
+		CartMenuResponseDTO mangoBananaInCart = cartService.addMenu(member.getId(), mangoBanana.getId(), 1);
+		List<CartMenuResponseDTO> responses = List.of(icedAmericanoInCart, mangoBananaInCart);
 
-		List<CartMenuResponseDTO> responses = List.of(
-			new CartMenuResponseDTO(icedAmericanoInCart),
-			new CartMenuResponseDTO(mangoBananaInCart)
-		);
-
-		mvc.perform(MockMvcRequestBuilders.get("/members/{memberId}/cart", member.getId()))
+		mvc.perform(get("/members/{memberId}/cart", member.getId()))
 			.andExpect(status().isOk())
 			.andExpect(content().json(objectMapper.writeValueAsString(responses)));
 	}


### PR DESCRIPTION
- 장바구니에 메뉴를 추가 시, 현재 회원의 장바구니가 없다면 새로운 장바구니를 생성 후 추가
  * 회원의 id로 장바구니를 조회하는 과정에서, `orElse()`로 인해 매번 새로운 장바구니가 생성되는 버그가 확인됨
  * 현재는 `orElse()` 대신 `orElseGet()`을 통해 수정함
- 장바구니에 메뉴를 추가하는 API 추가 (`/members/{memberId}/cart`)
  * 요청 시, 회원 id와 메뉴 id, 메뉴의 개수를 전달