### PR TITLE
메뉴 그룹에 대표 이미지 추가

### DIFF
--- a/src/main/java/com/jaw/menu/domain/MenuGroup.java
+++ b/src/main/java/com/jaw/menu/domain/MenuGroup.java
@@ -21,14 +21,17 @@ public class MenuGroup {
 
     private String englishName;
 
+    private String representativeImagePath;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 
     @Builder
-    public MenuGroup(String name, String englishName, Category category) {
+    public MenuGroup(String name, String englishName, String representativeImagePath, Category category) {
         this.name = name;
         this.englishName = englishName;
+        this.representativeImagePath = representativeImagePath;
         this.category = category;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  profiles:
+    active: dev
+
+---
+spring:
   config:
     activate:
       on-profile: prod

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,10 @@ spring:
         show_sql: true
         format_sql: true
 
+  sql:
+    init:
+      data-locations: classpath*:data.sql
+
   h2:
     console:
       enabled: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,38 +4,38 @@ VALUES
 (2, '푸드'),
 (3, '상품');
 
-INSERT INTO menu_group(MENU_GROUP_ID, CATEGORY_ID, NAME, ENGLISH_NAME)
+INSERT INTO menu_group(MENU_GROUP_ID, CATEGORY_ID, NAME, ENGLISH_NAME, REPRESENTATIVE_IMAGE_PATH)
 VALUES
-(1, 1, '콜드 브루', 'Cold Brew'),
-(2, 1, '에스프레소', 'Espresso'),
-(3, 1, '프라푸치노', 'Frappuccino'),
-(4, 1, '블렌디드', 'Blended'),
-(5, 1, '피지오', 'Starbucks Fizzio'),
-(6, 1, '티바나', 'Teavana'),
-(7, 1, '브루드 커피', 'Brewed Coffee'),
-(8, 1, '기타', 'Others'),
-(9, 1, '병음료', 'RTD'),
+(1, 1, '콜드 브루', 'Cold Brew', '/images/cold_brew.jpg'),
+(2, 1, '에스프레소', 'Espresso', '/images/iced_caffe_americano.jpg'),
+(3, 1, '프라푸치노', 'Frappuccino', '/images/mocha_frappuccino.jpg'),
+(4, 1, '블렌디드', 'Blended', '/images/mango_banana_blended.jpg'),
+(5, 1, '피지오', 'Starbucks Fizzio', '/images/cool_lime_starbucks_fizzio.jpg'),
+(6, 1, '티바나', 'Teavana', '/images/pomelo_flow_green_tea.jpg'),
+(7, 1, '브루드 커피', 'Brewed Coffee', '/images/brewed_coffee.jpg'),
+(8, 1, '기타', 'Others', '/images/iced_signature_chocolate.jpg'),
+(9, 1, '병음료', 'RTD', '/images/organic_orange_100_juice_190ml.jpg'),
 
-(10, 2, '브레드', 'Bread'),
-(11, 2, '케이크&미니디저트', 'Cake&Mini Dessert'),
-(12, 2, '샌드위치&샐러드', 'Sandwich&Salad'),
-(13, 2, '따뜻한 푸드', 'Hot Food'),
-(14, 2, '과일&요거트', 'Fruit&Yogurt'),
-(15, 2, '스낵', 'Snack'),
-(16, 2, '아이스크림', 'Ice Cream'),
-(17, 2, '스타디움 세트', 'Stadium Set'),
+(10, 2, '브레드', 'Bread', null),
+(11, 2, '케이크&미니디저트', 'Cake&Mini Dessert', null),
+(12, 2, '샌드위치&샐러드', 'Sandwich&Salad', null),
+(13, 2, '따뜻한 푸드', 'Hot Food', null),
+(14, 2, '과일&요거트', 'Fruit&Yogurt', null),
+(15, 2, '스낵', 'Snack', null),
+(16, 2, '아이스크림', 'Ice Cream', null),
+(17, 2, '스타디움 세트', 'Stadium Set', null),
 
-(18, 3, '머그/글라스', 'Mug/Glass'),
-(19, 3, '스테인리스텀블러', 'Stainless steel Tumbler'),
-(20, 3, '플라스틱텀블러', 'Plastic Tumbler'),
-(21, 3, '보온병', 'Vaccum flask'),
-(22, 3, '엑세서리', 'ACC'),
-(23, 3, '커피용품', 'Brewing Item'),
-(24, 3, '원두','Whole bean'),
-(25, 3, '비아', 'VIA'),
-(26, 3, '스타벅스앳홈 by 캡슐', 'Starbucks at Home by capsule'),
-(27, 3, '패키지 티', 'Packaged Tea'),
-(28, 3, '리저브 원두', 'Reserve Whole bean');
+(18, 3, '머그/글라스', 'Mug/Glass', null),
+(19, 3, '스테인리스텀블러', 'Stainless steel Tumbler', null),
+(20, 3, '플라스틱텀블러', 'Plastic Tumbler', null),
+(21, 3, '보온병', 'Vaccum flask', null),
+(22, 3, '엑세서리', 'ACC', null),
+(23, 3, '커피용품', 'Brewing Item', null),
+(24, 3, '원두','Whole bean', null),
+(25, 3, '비아', 'VIA', null),
+(26, 3, '스타벅스앳홈 by 캡슐', 'Starbucks at Home by capsule', null),
+(27, 3, '패키지 티', 'Packaged Tea', null),
+(28, 3, '리저브 원두', 'Reserve Whole bean', null);
 
 INSERT INTO menu(MENU_GROUP_ID, NAME, ENGLISH_NAME, PRICE, ON_SALE, DESCRIPTION, IMAGE_PATH)
 VALUES

--- a/src/test/java/com/jaw/category/application/CategoryServiceTest.java
+++ b/src/test/java/com/jaw/category/application/CategoryServiceTest.java
@@ -1,21 +1,20 @@
 package com.jaw.category.application;
 
-import static org.assertj.core.api.Assertions.*;
-
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import com.jaw.category.domain.Category;
 import com.jaw.category.ui.CategoryMenuGroupsResponseDTO;
 import com.jaw.category.ui.CategoryRequestDTO;
 import com.jaw.category.ui.CategoryResponseDTO;
 import com.jaw.menu.application.InMemoryMenuGroupRepository;
 import com.jaw.menu.domain.MenuGroup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CategoryServiceTest {
 
@@ -65,12 +64,19 @@ class CategoryServiceTest {
     void findWithMenuGroupsById() {
         Category category = categoryRepository.save(categoryRepository.save(new Category("탄산음료")));
 
-        menuGroupRepository.save(new MenuGroup("콜라", "Coke", category));
-        menuGroupRepository.save(new MenuGroup("사이다", "Cider", category));
+        menuGroupRepository.save(menuGroup("콜라", "Coke", category));
+        menuGroupRepository.save(menuGroup("사이다", "Cider", category));
 
         CategoryMenuGroupsResponseDTO foundCategory = categoryService.findWithMenuGroupsById(category.getId());
         assertThat(foundCategory.getName()).isEqualTo("탄산음료");
         assertThat(foundCategory.getMenuGroups()).hasSize(2);
     }
 
+    private MenuGroup menuGroup(String name, String englishName, Category category) {
+        return MenuGroup.builder()
+            .name(name)
+            .englishName(englishName)
+            .category(category)
+            .build();
+    }
 }

--- a/src/test/java/com/jaw/menu/ui/MenuGroupRestControllerTest.java
+++ b/src/test/java/com/jaw/menu/ui/MenuGroupRestControllerTest.java
@@ -1,10 +1,10 @@
 package com.jaw.menu.ui;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.List;
-
+import com.jaw.AbstractControllerTest;
+import com.jaw.menu.domain.Menu;
+import com.jaw.menu.domain.MenuGroup;
+import com.jaw.menu.domain.MenuGroupRepository;
+import com.jaw.menu.domain.MenuRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,11 +14,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.jaw.AbstractControllerTest;
-import com.jaw.menu.domain.Menu;
-import com.jaw.menu.domain.MenuGroup;
-import com.jaw.menu.domain.MenuGroupRepository;
-import com.jaw.menu.domain.MenuRepository;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -50,8 +50,8 @@ class MenuGroupRestControllerTest extends AbstractControllerTest {
     @DisplayName("메뉴 그룹 목록을 조회한다.")
     @Test
     void findAll() throws Exception {
-        MenuGroup coldBrew = menuGroupRepository.save(new MenuGroup("콜드 브루", "Cold Brew", null));
-        MenuGroup blonde = menuGroupRepository.save(new MenuGroup("블론드", "Blonde Coffee", null));
+        MenuGroup coldBrew = menuGroupRepository.save(menuGroup("콜드 브루", "Cold Brew"));
+        MenuGroup blonde = menuGroupRepository.save(menuGroup("블론드", "Blonde Coffee"));
 
         List<MenuGroupResponseDTO> menuGroups = List.of(
             new MenuGroupResponseDTO(coldBrew),
@@ -66,7 +66,7 @@ class MenuGroupRestControllerTest extends AbstractControllerTest {
     @DisplayName("특정 메뉴 그룹을 조회한다.")
     @Test
     void findById() throws Exception {
-        MenuGroup frappuccino = menuGroupRepository.save(new MenuGroup("프라푸치노", "Frappuccino", null));
+        MenuGroup frappuccino = menuGroupRepository.save(menuGroup("프라푸치노", "Frappuccino"));
 
         MenuGroupResponseDTO menuGroup = new MenuGroupResponseDTO(frappuccino);
 
@@ -78,7 +78,7 @@ class MenuGroupRestControllerTest extends AbstractControllerTest {
     @DisplayName("특정 메뉴 그룹 조회 시, 하위의 메뉴 목록을 함께 조회한다.")
     @Test
     void findWithMenusById() throws Exception {
-        MenuGroup espresso = menuGroupRepository.save(new MenuGroup("에스프레소", "Espresso", null));
+        MenuGroup espresso = menuGroupRepository.save(menuGroup("에스프레소", "Espresso"));
         Menu macchiato = menuRepository.save(menu("에스프레소 마키아또", "Espresso Macchiato", 4_000, espresso));
         Menu conPanna = menuRepository.save(menu("에스프레소 콘 파나", "Espresso Con Panna", 4_200, espresso));
 
@@ -87,6 +87,13 @@ class MenuGroupRestControllerTest extends AbstractControllerTest {
         mvc.perform(get(BASE_URI + "/{menuGroupId}/menus", espresso.getId()))
             .andExpect(status().isOk())
             .andExpect(content().json(objectMapper.writeValueAsString(menuGroup)));
+    }
+
+    private MenuGroup menuGroup(String name, String englishName) {
+        return MenuGroup.builder()
+            .name(name)
+            .englishName(englishName)
+            .build();
     }
 
     private Menu menu(String name, String englishName, long price, MenuGroup menuGroup) {


### PR DESCRIPTION
### 추가한 기능
- 메뉴 그룹에 대표 이미지 추가

### 고민
- MenuGroup 조회 시, Menu를 fetch join한 다음 첫 번째 메뉴에서 이미지를 꺼낼지?
- MenuGroup 엔티티에 대표 이미지 경로 필드를 추가할지?

### 결론
- MenuGroup 대표 이미지를 보여주기 위해 Menu를 가져오려면 Category - MenuGroup - Menu 까지 join을 해야 함
- MenuGroup에 대표 이미지 경로 필드를 추가하고, 필요에 따라 관리자가 이미지를 선택하도록 하는 것이 좋아 보임