### PR TITLE
[Fix] 메뉴 그룹 조회 시, 응답 데이터에 대표 이미지가 포함되도록 수정

### DIFF
--- a/src/main/java/com/jaw/CoffeeAndTasteApiServerApplication.java
+++ b/src/main/java/com/jaw/CoffeeAndTasteApiServerApplication.java
@@ -1,11 +1,8 @@
 package com.jaw;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@OpenAPIDefinition(servers = @Server(url = "https://coffee-and-taste.kro.kr"))
 @SpringBootApplication
 public class CoffeeAndTasteApiServerApplication {
 

--- a/src/main/java/com/jaw/config/OpenAPIConfiguration.java
+++ b/src/main/java/com/jaw/config/OpenAPIConfiguration.java
@@ -1,0 +1,29 @@
+package com.jaw.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenAPIConfiguration {
+
+    private static final String URL_PROD = "https://coffee-and-taste.kro.kr";
+    private static final String URL_DEV = "http://localhost:8080";
+
+    @Bean
+    public OpenAPI openAPI() {
+        Server prod = createServer(URL_PROD, "Production");
+        Server dev = createServer(URL_DEV, "Development");
+        return new OpenAPI().servers(List.of(prod, dev));
+    }
+
+    public Server createServer(String url, String description) {
+        Server server = new Server();
+        server.setUrl(url);
+        server.setDescription(description);
+        return server;
+    }
+}

--- a/src/main/java/com/jaw/menu/ui/MenuGroupRequestDTO.java
+++ b/src/main/java/com/jaw/menu/ui/MenuGroupRequestDTO.java
@@ -1,11 +1,9 @@
 package com.jaw.menu.ui;
 
 import com.jaw.menu.domain.MenuGroup;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @AllArgsConstructor
@@ -14,11 +12,13 @@ public class MenuGroupRequestDTO {
 
     private String name;
     private String englishName;
+    private String representativeImagePath;
 
     public MenuGroup toEntity() {
         return MenuGroup.builder()
             .name(name)
             .englishName(englishName)
+            .representativeImagePath(representativeImagePath)
             .build();
     }
 }

--- a/src/main/java/com/jaw/menu/ui/MenuGroupResponseDTO.java
+++ b/src/main/java/com/jaw/menu/ui/MenuGroupResponseDTO.java
@@ -6,13 +6,15 @@ import lombok.Getter;
 @Getter
 public class MenuGroupResponseDTO {
 
-    private Long id;
-    private String name;
-    private String englishName;
+    private final Long id;
+    private final String name;
+    private final String englishName;
+    private final String representativeImagePath;
 
     public MenuGroupResponseDTO(MenuGroup menuGroup) {
         this.id = menuGroup.getId();
         this.name = menuGroup.getName();
         this.englishName = menuGroup.getEnglishName();
+        this.representativeImagePath = menuGroup.getRepresentativeImagePath();
     }
 }

--- a/src/test/java/com/jaw/menu/application/MenuGroupServiceTest.java
+++ b/src/test/java/com/jaw/menu/application/MenuGroupServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,11 +39,13 @@ class MenuGroupServiceTest {
     void create() {
         String name = "에스프레소";
         String englishName = "Espresso";
-        MenuGroupResponseDTO response = menuGroupService.create(new MenuGroupRequestDTO(name, englishName));
+        String imagePath = "/images/espresso.jpg";
+        MenuGroupResponseDTO response = menuGroupService.create(new MenuGroupRequestDTO(name, englishName, imagePath));
         assertAll(
             () -> assertThat(response.getId()).isEqualTo(1L),
             () -> assertThat(response.getName()).isEqualTo(name),
-            () -> assertThat(response.getEnglishName()).isEqualTo(englishName)
+            () -> assertThat(response.getEnglishName()).isEqualTo(englishName),
+            () -> assertThat(response.getRepresentativeImagePath()).isEqualTo(imagePath)
         );
     }
 

--- a/src/test/java/com/jaw/menu/ui/MenuGroupRestControllerTest.java
+++ b/src/test/java/com/jaw/menu/ui/MenuGroupRestControllerTest.java
@@ -37,14 +37,15 @@ class MenuGroupRestControllerTest extends AbstractControllerTest {
     @DisplayName("새로운 메뉴 그룹을 등록한다.")
     @Test
     void create() throws Exception {
-        MenuGroupRequestDTO request = new MenuGroupRequestDTO("블렌디드", "Blended");
+        MenuGroupRequestDTO request = new MenuGroupRequestDTO("블렌디드", "Blended", "blended.jpg");
 
         mvc.perform(post(BASE_URI)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.name").value("블렌디드"))
-            .andExpect(jsonPath("$.englishName").value("Blended"));
+            .andExpect(jsonPath("$.englishName").value("Blended"))
+            .andExpect(jsonPath("$.representativeImagePath").value("blended.jpg"));
     }
 
     @DisplayName("메뉴 그룹 목록을 조회한다.")


### PR DESCRIPTION
#### 문제 확인 및 원인
- 메뉴 그룹 조회 요청 시, 응답 데이터에 대표 이미지 경로가 누락됨
- 메뉴 그룹 응답 DTO 객체에 대표 이미지 경로 필드를 추가하지 않았었음

#### 조치
- 메뉴 그룹 요청 및 응답 DTO에 대표 이미지 필드 추가

#### 추가 조치
- OpenAPI 서버 설정 추가 (`prod`, `dev`)

![image](https://user-images.githubusercontent.com/64854054/172508078-29777fbc-36dc-4a30-8b6c-c2999af7b333.png)
