### PR TITLE
특정 회원은 본인의 장바구니에만 접근이 가능하도록 권한을 부여

### DIFF
--- a/src/main/java/com/jaw/auth/UserAuthentication.java
+++ b/src/main/java/com/jaw/auth/UserAuthentication.java
@@ -25,6 +25,10 @@ public class UserAuthentication extends AbstractAuthenticationToken {
 			.collect(Collectors.toList());
 	}
 
+	public Long getUserId() {
+		return userId;
+	}
+
 	@Override
 	public boolean isAuthenticated() {
 		return true;

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -1,5 +1,6 @@
 package com.jaw.cart.ui;
 
+import com.jaw.auth.UserAuthentication;
 import com.jaw.cart.application.CartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,16 +19,20 @@ public class CartRestController {
 
 	@GetMapping
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<List<CartMenuResponseDTO>> findAll(@PathVariable Long memberId) {
-		return ResponseEntity.ok(cartService.findAll(memberId));
+	public ResponseEntity<List<CartMenuResponseDTO>> findAll(@PathVariable Long memberId,
+															 UserAuthentication authentication) {
+		Long userId = authentication.getUserId();
+		return ResponseEntity.ok(cartService.findAll(memberId, userId));
 	}
 
 	@PostMapping
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<CartMenuResponseDTO> addMenu(@PathVariable Long memberId,
-													   @RequestBody CartMenuRequestDTO request) {
+													   @RequestBody CartMenuRequestDTO request,
+													   UserAuthentication authentication) {
 
-		CartMenuResponseDTO cartMenu = cartService.addMenu(memberId, request.getMenuId(), request.getCount());
+		Long userId = authentication.getUserId();
+		CartMenuResponseDTO cartMenu = cartService.addMenu(memberId, userId, request);
 		return ResponseEntity.created(URI.create(String.format("/api/members/%d/cart", memberId)))
 			.body(cartMenu);
 	}

--- a/src/main/java/com/jaw/exception/MemberNotFoundException.java
+++ b/src/main/java/com/jaw/exception/MemberNotFoundException.java
@@ -1,0 +1,14 @@
+package com.jaw.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class MemberNotFoundException extends RuntimeException {
+
+    private static final String MESSAGE = "존재하지 않는 사용자입니다. (현재 이메일 : %s)";
+
+    public MemberNotFoundException(String email) {
+        super(String.format(MESSAGE, email));
+    }
+}

--- a/src/main/java/com/jaw/exception/UserEmailDuplicationException.java
+++ b/src/main/java/com/jaw/exception/UserEmailDuplicationException.java
@@ -1,0 +1,14 @@
+package com.jaw.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class UserEmailDuplicationException extends RuntimeException {
+
+    private static final String MESSAGE = "이미 등록된 이메일입니다 : %s";
+
+    public UserEmailDuplicationException(String email) {
+        super(String.format(MESSAGE, email));
+    }
+}

--- a/src/main/java/com/jaw/member/application/MemberService.java
+++ b/src/main/java/com/jaw/member/application/MemberService.java
@@ -1,18 +1,17 @@
 package com.jaw.member.application;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.jaw.exception.MemberNotFoundException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.jaw.exception.UserEmailDuplicationException;
 import com.jaw.member.domain.Member;
 import com.jaw.member.domain.MemberRepository;
 import com.jaw.member.ui.MemberRequestDTO;
 import com.jaw.member.ui.MemberResponseDTO;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
@@ -22,6 +21,11 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	public MemberResponseDTO create(MemberRequestDTO request) {
+		String email = request.getEmail();
+		if (memberRepository.findByEmail(email).isPresent()) {
+			throw new UserEmailDuplicationException(email);
+		}
+
 		Member member = memberRepository.save(request.toEntity());
 		return new MemberResponseDTO(member);
 	}

--- a/src/main/java/com/jaw/member/application/MemberService.java
+++ b/src/main/java/com/jaw/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.jaw.member.application;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.jaw.exception.MemberNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +36,6 @@ public class MemberService {
 	public MemberResponseDTO findByEmail(String email) {
 		return memberRepository.findByEmail(email)
 			.map(MemberResponseDTO::new)
-			.orElseThrow(IllegalArgumentException::new);
+			.orElseThrow(() -> new MemberNotFoundException(email));
 	}
 }

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.jaw.cart.ui.CartMenuRequestDTO;
 import com.jaw.cart.ui.CartMenuResponseDTO;
 import com.jaw.member.application.InMemoryMemberRepository;
 import com.jaw.member.domain.Member;
@@ -46,10 +47,13 @@ class CartServiceTest {
 		Menu vanillaFlatWhite = menuRepository.save(menu("바닐라 플랫 화이트", 5_900));
 		Menu icedCaffeMocha = menuRepository.save(menu("아이스 카페 모카", 5_500));
 
-		cartService.addMenu(member.getId(), vanillaFlatWhite.getId(), 1);
-		cartService.addMenu(member.getId(), icedCaffeMocha.getId(), 1);
+		CartMenuRequestDTO vanillaFlatWhiteRequest = new CartMenuRequestDTO(vanillaFlatWhite.getId(), 1);
+		CartMenuRequestDTO icedCaffeMochaRequest = new CartMenuRequestDTO(icedCaffeMocha.getId(), 2);
 
-		List<CartMenuResponseDTO> cartMenus = cartService.findAll(member.getId());
+		cartService.addMenu(member.getId(), member.getId(), vanillaFlatWhiteRequest);
+		cartService.addMenu(member.getId(), member.getId(), icedCaffeMochaRequest);
+
+		List<CartMenuResponseDTO> cartMenus = cartService.findAll(member.getId(), member.getId());
 
 		assertThat(cartMenus).hasSize(2);
 	}

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -37,7 +37,7 @@ class CartRestControllerTest extends AbstractControllerTest {
 	private Member member;
 
 	@BeforeEach
-	protected void setup() {
+	void setup() {
 		member = memberRepository.save(Member.builder()
 			.name("홍길동")
 			.nickname("hong")

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -137,6 +137,14 @@ class CartRestControllerTest extends AbstractControllerTest {
 			.andExpect(content().json(objectMapper.writeValueAsString(responses)));
 	}
 
+	@DisplayName("회원은 다른 회원의 장바구니에 담긴 메뉴 목록을 조회할 수 없다.")
+	@Test
+	void findAllOtherUserCart() throws Exception {
+		mvc.perform(get(BASE_URI, other.getId())
+				.header("Authorization", "Bearer " + JWT_UTIL.encode(member.getId())))
+			.andExpect(status().isForbidden());
+	}
+
 	@DisplayName("장바구니에 담긴 모든 메뉴 조회 요청 시, 인증 토큰이 유효하지 않을 경우 HTTP 401 응답을 내려준다.")
 	@Test
 	void findAllWithInvalidToken() throws Exception {

--- a/src/test/java/com/jaw/member/application/MemberServiceTest.java
+++ b/src/test/java/com/jaw/member/application/MemberServiceTest.java
@@ -1,17 +1,18 @@
 package com.jaw.member.application;
 
-import static org.assertj.core.api.Assertions.*;
-
-import java.time.LocalDate;
-import java.util.List;
-
+import com.jaw.exception.MemberNotFoundException;
+import com.jaw.member.ui.MemberRequestDTO;
+import com.jaw.member.ui.MemberResponseDTO;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.jaw.member.ui.MemberRequestDTO;
-import com.jaw.member.ui.MemberResponseDTO;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MemberServiceTest {
 
@@ -53,6 +54,15 @@ class MemberServiceTest {
 		MemberResponseDTO member = memberService.findByEmail("aaa@gmail.com");
 		assertThat(member.getName()).isEqualTo("memberA");
 		assertThat(member.getEmail()).isEqualTo("aaa@gmail.com");
+	}
+
+	@DisplayName("존재하지 않는 이메일로 회원을 조회할 경우, MemberNotFoundException 예외가 발생한다.")
+	@Test
+	void findByNonExistentEmail() {
+		memberRepository.save(member("memberA", "aaa@gmail.com").toEntity());
+
+		assertThatThrownBy(() -> memberService.findByEmail("bbb@gmail.com"))
+			.isInstanceOf(MemberNotFoundException.class);
 	}
 
 	private MemberRequestDTO member(String name, String email) {

--- a/src/test/java/com/jaw/member/application/MemberServiceTest.java
+++ b/src/test/java/com/jaw/member/application/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.jaw.member.application;
 
 import com.jaw.exception.MemberNotFoundException;
+import com.jaw.exception.UserEmailDuplicationException;
 import com.jaw.member.ui.MemberRequestDTO;
 import com.jaw.member.ui.MemberResponseDTO;
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +36,16 @@ class MemberServiceTest {
 	void create() {
 		MemberResponseDTO member = memberService.create(member( "memberA", "aaa@gmail.com"));
 		assertThat(member.getId()).isEqualTo(1L);
+	}
+
+	@DisplayName("회원 등록 시, 이미 등록된 이메일이라면 등록할 수 없다.")
+	@Test
+	void createWithDuplicateEmail() {
+		memberService.create(member("memberA", "aaa@gmail.com"));
+		MemberRequestDTO createMemberRequest = member("memberB", "aaa@gmail.com");
+
+		assertThatThrownBy(() -> memberService.create(createMemberRequest))
+			.isInstanceOf(UserEmailDuplicationException.class);
 	}
 
 	@DisplayName("회원 목록을 조회한다.")

--- a/src/test/java/com/jaw/order/ui/OrderRestControllerTest.java
+++ b/src/test/java/com/jaw/order/ui/OrderRestControllerTest.java
@@ -28,7 +28,7 @@ class OrderRestControllerTest extends AbstractControllerTest {
 	private Menu icedCoffee;
 
 	@BeforeEach
-	protected void setup() {
+	void setup() {
 		coldBrew = menuRepository.save(menu("콜드 브루", 4_900));
 		icedCoffee = menuRepository.save(menu("아이스 커피", 4_500));
 	}


### PR DESCRIPTION
- 현재 인증된 사용자의 id와 장바구니 API에 전달한 사용자의 id를 비교하여 일치하지 않으면 403 응답을 반환한다
- 적용된 API 목록
  * 장바구니에 메뉴 추가
  * 장바구니에 담긴 메뉴 목록 조회