### PR TITLE
최초 회원 장바구니 조회 요청 시, 장바구니가 생성되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/jaw/cart/application/CartService.java
+++ b/src/main/java/com/jaw/cart/application/CartService.java
@@ -39,7 +39,6 @@ public class CartService {
 		return new CartMenuResponseDTO(cartMenu);
 	}
 
-	@Transactional(readOnly = true)
 	public List<CartMenuResponseDTO> findAll(Long memberId, Long userId) {
 		validateUserAuthentication(memberId, userId);
 		Cart cart = findCartByMemberId(memberId);


### PR DESCRIPTION
#### 기존 (`readOnly = true` 옵션 때문에 장바구니 생성이 안 됐음)
```
@Transactional(readOnly = true)
public List<CartMenuResponseDTO> findAll(Long memberId, Long userId) {
    validateUserAuthentication(memberId, userId);
    Cart cart = findCartByMemberId(memberId); // 조회 결과가 없으면 장바구니를 생성
    return cartMenuRepository.findAllByCart(cart)
    	.stream()
	.map(CartMenuResponseDTO::new)
	.collect(Collectors.toList());
}
```

#### 수정 (`readOnly = true` 옵션 제거)
```
public List<CartMenuResponseDTO> findAll(Long memberId, Long userId) {
    validateUserAuthentication(memberId, userId);
    Cart cart = findCartByMemberId(memberId); // 조회 결과가 없으면 장바구니를 생성
    return cartMenuRepository.findAllByCart(cart)
    	.stream()
	.map(CartMenuResponseDTO::new)
	.collect(Collectors.toList());
}
```