### PR TITLE
회원 등록 시, Role을 'USER'로 추가한다

### DIFF
--- a/src/main/java/com/jaw/member/application/MemberService.java
+++ b/src/main/java/com/jaw/member/application/MemberService.java
@@ -11,6 +11,8 @@ import com.jaw.exception.MemberNotFoundException;
 import com.jaw.exception.UserEmailDuplicationException;
 import com.jaw.member.domain.Member;
 import com.jaw.member.domain.MemberRepository;
+import com.jaw.member.domain.Role;
+import com.jaw.member.domain.RoleRepository;
 import com.jaw.member.ui.MemberRequestDTO;
 import com.jaw.member.ui.MemberResponseDTO;
 import com.jaw.member.ui.MemberUpdateRequestDTO;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final RoleRepository roleRepository;
 	private final PasswordEncoder passwordEncoder;
 
 	public MemberResponseDTO create(MemberRequestDTO request) {
@@ -34,6 +37,7 @@ public class MemberService {
 
 		request.setPassword(passwordEncoder.encode(request.getPassword()));
 		Member member = memberRepository.save(request.toEntity());
+		roleRepository.save(new Role(member.getId(), "USER"));
 		return new MemberResponseDTO(member);
 	}
 

--- a/src/main/java/com/jaw/member/ui/MemberUpdateResponseDTO.java
+++ b/src/main/java/com/jaw/member/ui/MemberUpdateResponseDTO.java
@@ -1,16 +1,13 @@
 package com.jaw.member.ui;
 
-import com.jaw.member.domain.Member;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import java.time.format.DateTimeFormatter;
 
+import com.jaw.member.domain.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
 @Getter
-@Setter
-@NoArgsConstructor
 public class MemberUpdateResponseDTO {
 
     private Long id;

--- a/src/test/java/com/jaw/member/application/MemberServiceTest.java
+++ b/src/test/java/com/jaw/member/application/MemberServiceTest.java
@@ -81,6 +81,15 @@ class MemberServiceTest {
 		assertThat(member.getEmail()).isEqualTo("aaa@gmail.com");
 	}
 
+	@DisplayName("식별자로 회원을 조회한다.")
+	@Test
+	void findById() {
+		MemberResponseDTO member = memberService.create(memberCreateRequest("memberA", "aaa@gmail.com", "1234"));
+		MemberResponseDTO foundMember = memberService.findById(member.getId());
+		assertThat(foundMember.getName()).isEqualTo("memberA");
+		assertThat(foundMember.getEmail()).isEqualTo("aaa@gmail.com");
+	}
+
 	@DisplayName("존재하지 않는 이메일로 회원을 조회할 경우, MemberNotFoundException 예외가 발생한다.")
 	@Test
 	void findByNonExistentEmail() {

--- a/src/test/java/com/jaw/member/application/MemberServiceTest.java
+++ b/src/test/java/com/jaw/member/application/MemberServiceTest.java
@@ -3,6 +3,7 @@ package com.jaw.member.application;
 import static com.jaw.Fixtures.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,6 +18,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.jaw.exception.MemberNotFoundException;
 import com.jaw.exception.UserEmailDuplicationException;
 import com.jaw.member.domain.Member;
+import com.jaw.member.domain.Role;
+import com.jaw.member.domain.RoleRepository;
 import com.jaw.member.ui.MemberRequestDTO;
 import com.jaw.member.ui.MemberResponseDTO;
 import com.jaw.member.ui.MemberUpdateRequestDTO;
@@ -24,6 +27,7 @@ import com.jaw.member.ui.MemberUpdateRequestDTO;
 class MemberServiceTest {
 
 	private InMemoryMemberRepository memberRepository;
+	private final RoleRepository roleRepository = mock(RoleRepository.class);
 	private PasswordEncoder passwordEncoder;
 	private MemberService memberService;
 
@@ -31,7 +35,7 @@ class MemberServiceTest {
 	void setup() {
 		memberRepository = new InMemoryMemberRepository();
 		passwordEncoder = new BCryptPasswordEncoder();
-		memberService = new MemberService(memberRepository, passwordEncoder);
+		memberService = new MemberService(memberRepository, roleRepository, passwordEncoder);
 	}
 
 	@AfterEach
@@ -44,6 +48,8 @@ class MemberServiceTest {
 	void create() {
 		MemberResponseDTO member = memberService.create(memberCreateRequest("memberA", "aaa@gmail.com", "1234"));
 		assertThat(member.getId()).isEqualTo(1L);
+
+		verify(roleRepository).save(any(Role.class));
 	}
 
 	@DisplayName("회원 등록 시, 이미 등록된 이메일이라면 등록할 수 없다.")


### PR DESCRIPTION
- 기존에는 회원 등록 시 Role을 추가하지 않아서, 회원 정보 요청 시 403 응답이 내려왔음
- 회원 등록 시, 기본적으로 'USER'라는 Role을 추가하도록 수정함