### PR TITLE
CORS 설정 변경 (허용할 HTTP 메서드 추가)

### DIFF
--- a/src/main/java/com/jaw/config/WebConfiguration.java
+++ b/src/main/java/com/jaw/config/WebConfiguration.java
@@ -11,6 +11,6 @@ public class WebConfiguration implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
 			.allowedOrigins("*")
-			.allowedMethods("GET", "POST", "PUT", "DELETE");
+			.allowedMethods("*");
 	}
 }


### PR DESCRIPTION
* 관련 이슈 : https://github.com/jack-and-whoop/coffee-and-taste-api-server/issues/39
* 허용하는 HTTP 메서드
  - 기존 : `GET`, `POST`, `PUT`, `DELETE`
  - 변경 : 모든 HTTP 메서드