### PR TITLE
장바구니 메뉴 삭제 API 변경 및 금액 필드 추가

### DIFF
--- a/src/main/java/com/jaw/cart/domain/CartMenu.java
+++ b/src/main/java/com/jaw/cart/domain/CartMenu.java
@@ -15,6 +15,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.math.BigDecimal;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -33,10 +35,13 @@ public class CartMenu {
 
 	private Long quantity;
 
+	private BigDecimal price;
+
 	public CartMenu(Cart cart, Menu menu, Long quantity) {
 		this.cart = cart;
 		this.menu = menu;
 		this.quantity = quantity;
+		this.price = menu.getPrice().multiply(BigDecimal.valueOf(quantity));
 	}
 
 	public OrderMenu toOrderMenu() {

--- a/src/main/java/com/jaw/cart/domain/CartMenuRepository.java
+++ b/src/main/java/com/jaw/cart/domain/CartMenuRepository.java
@@ -12,4 +12,6 @@ public interface CartMenuRepository {
 	Optional<CartMenu> findById(Long id);
 
 	void delete(CartMenu cartMenu);
+
+	List<CartMenu> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/jaw/cart/ui/CartMenuDeleteRequest.java
+++ b/src/main/java/com/jaw/cart/ui/CartMenuDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.jaw.cart.ui;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CartMenuDeleteRequest {
+
+    private List<Long> cartMenuIds;
+}

--- a/src/main/java/com/jaw/cart/ui/CartMenuDeleteRequest.java
+++ b/src/main/java/com/jaw/cart/ui/CartMenuDeleteRequest.java
@@ -1,10 +1,14 @@
 package com.jaw.cart.ui;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CartMenuDeleteRequest {
 
     private List<Long> cartMenuIds;

--- a/src/main/java/com/jaw/cart/ui/CartMenuResponseDTO.java
+++ b/src/main/java/com/jaw/cart/ui/CartMenuResponseDTO.java
@@ -5,16 +5,20 @@ import com.jaw.menu.ui.MenuResponseDTO;
 
 import lombok.Getter;
 
+import java.math.BigDecimal;
+
 @Getter
 public class CartMenuResponseDTO {
 
 	private final Long id;
 	private final MenuResponseDTO menu;
 	private final Long quantity;
+	private final BigDecimal price;
 
 	public CartMenuResponseDTO(CartMenu cartMenu) {
 		this.id = cartMenu.getId();
 		this.menu = new MenuResponseDTO(cartMenu.getMenu());
 		this.quantity = cartMenu.getQuantity();
+		this.price = cartMenu.getPrice();
 	}
 }

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -1,23 +1,14 @@
 package com.jaw.cart.ui;
 
-import java.net.URI;
-
+import com.jaw.auth.UserAuthentication;
+import com.jaw.cart.application.CartService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import com.jaw.auth.UserAuthentication;
-import com.jaw.cart.application.CartService;
-
-import lombok.RequiredArgsConstructor;
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/cart")
@@ -59,18 +50,11 @@ public class CartRestController {
 		return ResponseEntity.ok(cartMenu);
 	}
 
-	@DeleteMapping("/cart-menus/{id}")
-	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<CartMenuResponseDTO> deleteCartMenu(@PathVariable Long id,
-															  UserAuthentication authentication) {
-		cartService.deleteCartMenuById(authentication.getUserId(), id);
-		return ResponseEntity.noContent().build();
-	}
-
 	@DeleteMapping("/cart-menus")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<CartResponseDTO> deleteAllCartMenus(UserAuthentication authentication) {
-		CartResponseDTO cart = cartService.deleteAllCartMenus(authentication.getUserId());
+	public ResponseEntity<CartResponseDTO> deleteCartMenus(@RequestBody CartMenuDeleteRequest request,
+														   UserAuthentication authentication) {
+		CartResponseDTO cart = cartService.deleteCartMenus(authentication.getUserId(), request.getCartMenuIds());
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(cart);
 	}
 

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -152,13 +152,14 @@ class CartServiceTest {
 		cartRepository.save(new Cart(member));
 		Menu menu = menuRepository.save(menu("아메리카노", 1_000L));
 		CartResponseDTO cartMenu = cartService.addCartMenu(member.getId(),
-			new CartMenuRequestDTO(menu.getId(), 1L));
+			new CartMenuRequestDTO(menu.getId(), 2L));
 
 		CartMenuResponseDTO foundCartMenu = cartService.findCartMenuById(member.getId(), cartMenu.getId());
 
 		assertThat(foundCartMenu.getMenu().getName()).isEqualTo("아메리카노");
 		assertThat(foundCartMenu.getMenu().getPrice()).isEqualTo(BigDecimal.valueOf(1_000L));
-		assertThat(foundCartMenu.getQuantity()).isEqualTo(1L);
+		assertThat(foundCartMenu.getQuantity()).isEqualTo(2L);
+		assertThat(foundCartMenu.getPrice()).isEqualTo(BigDecimal.valueOf(2_000L));
 	}
 
 	@DisplayName("장바구니 메뉴의 식별자가 유효하지 않다면, 장바구니에 담긴 메뉴를 조회할 수 없다.")

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -1,30 +1,26 @@
 package com.jaw.cart.application;
 
-import static com.jaw.Fixtures.*;
-import static org.assertj.core.api.Assertions.*;
-
-import java.math.BigDecimal;
-import java.util.List;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import com.jaw.cart.domain.Cart;
 import com.jaw.cart.domain.CartMenu;
-import com.jaw.cart.ui.CartMenuOrderRequestDTO;
-import com.jaw.cart.ui.CartMenuOrderResponseDTO;
-import com.jaw.cart.ui.CartMenuRequestDTO;
-import com.jaw.cart.ui.CartMenuResponseDTO;
-import com.jaw.cart.ui.CartMenuUpdateDTO;
-import com.jaw.cart.ui.CartResponseDTO;
+import com.jaw.cart.ui.*;
 import com.jaw.member.application.InMemoryMemberRepository;
 import com.jaw.member.domain.Member;
 import com.jaw.menu.application.InMemoryMenuRepository;
 import com.jaw.menu.domain.Menu;
 import com.jaw.order.application.InMemoryOrderRepository;
 import com.jaw.order.ui.OrderMenuResponseDTO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.jaw.Fixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CartServiceTest {
 
@@ -79,9 +75,9 @@ class CartServiceTest {
 		assertThat(foundCart.getCartMenus()).hasSize(2);
 	}
 
-	@DisplayName("장바구니에 담긴 모든 메뉴를 삭제한다.")
+	@DisplayName("장바구니에 담긴 메뉴를 삭제한다.")
 	@Test
-	void deleteAllCartMenus() {
+	void deleteCartMenus() {
 		Member member = memberRepository.save(member());
 		Menu vanillaFlatWhite = menuRepository.save(menu("바닐라 플랫 화이트", 5_900L));
 		Menu icedCaffeMocha = menuRepository.save(menu("아이스 카페 모카", 5_500L));
@@ -91,11 +87,24 @@ class CartServiceTest {
 		Cart cart = cartRepository.findByMemberId(member.getId())
 			.orElseThrow(IllegalArgumentException::new);
 
-		cartService.deleteAllCartMenus(member.getId());
+		cartService.deleteCartMenus(member.getId(), Arrays.asList(1L, 2L));
 
 		List<CartMenu> cartMenus = cartMenuRepository.findAllByCart(cart);
 
 		assertThat(cartMenus).isEmpty();
+	}
+
+	@DisplayName("삭제하고자 하는 메뉴가 장바구니에 없으면, 장바구니에 담긴 메뉴를 삭제할 수 없다.")
+	@Test
+	void deleteNonExistingCartMenus() {
+		Member member = memberRepository.save(member());
+		Menu vanillaFlatWhite = menuRepository.save(menu("바닐라 플랫 화이트", 5_900L));
+		Menu icedCaffeMocha = menuRepository.save(menu("아이스 카페 모카", 5_500L));
+		cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(vanillaFlatWhite.getId(), 1));
+		cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(icedCaffeMocha.getId(), 2));
+
+		assertThatThrownBy(() -> cartService.deleteCartMenus(member.getId(), List.of(999L)))
+			.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@DisplayName("장바구니에 메뉴를 추가한다.")
@@ -152,6 +161,17 @@ class CartServiceTest {
 		assertThat(foundCartMenu.getQuantity()).isEqualTo(1L);
 	}
 
+	@DisplayName("장바구니 메뉴의 식별자가 유효하지 않다면, 장바구니에 담긴 메뉴를 조회할 수 없다.")
+	@Test
+	void findCartMenuByNonExistingId() {
+		Member member = memberRepository.save(member());
+		cartRepository.save(new Cart(member));
+		CartMenu cartMenu = cartMenuRepository.save(new CartMenu(null, menu("아메리카노", 1_000L), 1L));
+
+		assertThatThrownBy(() -> cartService.findCartMenuById(member.getId(), cartMenu.getId()))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
 	@DisplayName("장바구니에 담긴 특정 메뉴의 수량을 변경한다.")
 	@Test
 	void changeCartMenuQuantity() {
@@ -176,33 +196,6 @@ class CartServiceTest {
 		CartMenuUpdateDTO updateRequest = new CartMenuUpdateDTO(2L);
 
 		assertThatThrownBy(() -> cartService.changeCartMenuQuantity(member.getId(), cartMenu.getId(), updateRequest))
-			.isInstanceOf(IllegalArgumentException.class);
-	}
-
-	@DisplayName("장바구니에 담긴 특정 메뉴를 삭제한다.")
-	@Test
-	void deleteCartMenuById() {
-		Member member = memberRepository.save(member());
-		Menu menu = menuRepository.save(menu("아메리카노", 1_000L));
-		CartResponseDTO cartMenu = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(menu.getId(), 1L));
-
-		cartService.deleteCartMenuById(member.getId(), cartMenu.getId());
-
-		assertThatThrownBy(() -> cartService.findCartMenuById(member.getId(), cartMenu.getId()))
-			.isInstanceOf(IllegalArgumentException.class);
-	}
-
-	@DisplayName("장바구니에 담긴 메뉴가 아니라면, 메뉴를 삭제할 수 없다.")
-	@Test
-	void deleteCartMenuByIdFailed() {
-		Member member = memberRepository.save(member());
-		Member other = memberRepository.save(other());
-		cartRepository.save(new Cart(member));
-		Cart otherCart = cartRepository.save(new Cart(other));
-		Menu menu = menuRepository.save(menu("아메리카노", 1_000L));
-		CartMenu carMenu = cartMenuRepository.save(new CartMenu(otherCart, menu, 1L));
-
-		assertThatThrownBy(() -> cartService.deleteCartMenuById(member.getId(), carMenu.getId()))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/com/jaw/cart/application/InMemoryCartMenuRepository.java
+++ b/src/test/java/com/jaw/cart/application/InMemoryCartMenuRepository.java
@@ -39,6 +39,14 @@ public class InMemoryCartMenuRepository implements CartMenuRepository {
 		cartMenus.remove(cartMenu.getId());
 	}
 
+	@Override
+	public List<CartMenu> findAllByIdIn(List<Long> ids) {
+		return cartMenus.values()
+			.stream()
+			.filter(cartMenu -> ids.contains(cartMenu.getId()))
+			.collect(Collectors.toList());
+	}
+
 	public void clear() {
 		sequence = 0;
 		cartMenus.clear();


### PR DESCRIPTION
- 장바구니 메뉴 삭제 시, 장바구니 메뉴의 식별자 목록을 전달받아 처리하도록 변경함
- 장바구니 메뉴 객체에 금액 필드를 추가함 (장바구니에 담긴 메뉴의 금액 * 수량으로 계산)