### PR TITLE
장바구니 메뉴 기능 및 API 추가

### DIFF
--- a/src/main/java/com/jaw/cart/application/CartService.java
+++ b/src/main/java/com/jaw/cart/application/CartService.java
@@ -79,6 +79,11 @@ public class CartService {
 		return new CartResponseDTO(cart);
 	}
 
+	public void deleteAllCartMenus(Long userId) {
+		Cart cart = findByUserId(userId);
+		cart.getCartMenus().forEach(cartMenuRepository::delete);
+	}
+
 	public CartMenuResponseDTO addCartMenu(Long userId, CartMenuRequestDTO request) {
 		Cart cart = findByUserId(userId);
 		Menu menu = menuRepository.findById(request.getMenuId())

--- a/src/main/java/com/jaw/cart/application/CartService.java
+++ b/src/main/java/com/jaw/cart/application/CartService.java
@@ -1,10 +1,22 @@
 package com.jaw.cart.application;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.jaw.cart.domain.Cart;
 import com.jaw.cart.domain.CartMenu;
 import com.jaw.cart.domain.CartMenuRepository;
 import com.jaw.cart.domain.CartRepository;
-import com.jaw.cart.ui.*;
+import com.jaw.cart.ui.CartMenuOrderRequestDTO;
+import com.jaw.cart.ui.CartMenuOrderResponseDTO;
+import com.jaw.cart.ui.CartMenuRequestDTO;
+import com.jaw.cart.ui.CartMenuResponseDTO;
+import com.jaw.cart.ui.CartMenuUpdateDTO;
+import com.jaw.cart.ui.CartResponseDTO;
 import com.jaw.member.domain.Member;
 import com.jaw.member.domain.MemberRepository;
 import com.jaw.menu.domain.Menu;
@@ -12,13 +24,8 @@ import com.jaw.menu.domain.MenuRepository;
 import com.jaw.order.domain.Order;
 import com.jaw.order.domain.OrderMenu;
 import com.jaw.order.domain.OrderRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Transactional
@@ -43,6 +50,18 @@ public class CartService {
 			.orElseGet(() -> cartRepository.save(new Cart(member)));
 	}
 
+	public void deleteCartMenu(Long userId, Long id) {
+		Cart cart = findByUserId(userId);
+
+		CartMenu cartMenu = cart.getCartMenus()
+			.stream()
+			.filter(menu -> menu.getId().equals(id))
+			.findFirst()
+			.orElseThrow(IllegalArgumentException::new);
+
+		cartMenuRepository.delete(cartMenu);
+	}
+
 	public CartResponseDTO deleteCartMenus(Long userId, List<Long> ids) {
 		Cart cart = findByUserId(userId);
 		List<CartMenu> cartMenus = cart.getCartMenus();
@@ -60,13 +79,13 @@ public class CartService {
 		return new CartResponseDTO(cart);
 	}
 
-	public CartResponseDTO addCartMenu(Long userId, CartMenuRequestDTO request) {
+	public CartMenuResponseDTO addCartMenu(Long userId, CartMenuRequestDTO request) {
 		Cart cart = findByUserId(userId);
 		Menu menu = menuRepository.findById(request.getMenuId())
 			.orElseThrow(IllegalArgumentException::new);
 		CartMenu cartMenu = cartMenuRepository.save(new CartMenu(cart, menu, request.getQuantity()));
 		cart.addMenu(cartMenu);
-		return new CartResponseDTO(cart);
+		return new CartMenuResponseDTO(cartMenu);
 	}
 
 	public CartMenuOrderResponseDTO orderCartMenus(Long userId, CartMenuOrderRequestDTO request) {

--- a/src/main/java/com/jaw/cart/domain/CartMenu.java
+++ b/src/main/java/com/jaw/cart/domain/CartMenu.java
@@ -1,5 +1,7 @@
 package com.jaw.cart.domain;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -14,8 +16,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.math.BigDecimal;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -51,5 +51,6 @@ public class CartMenu {
 
 	public void changeQuantity(Long quantity) {
 		this.quantity = quantity;
+		this.price = price.multiply(BigDecimal.valueOf(quantity));
 	}
 }

--- a/src/main/java/com/jaw/cart/domain/CartMenu.java
+++ b/src/main/java/com/jaw/cart/domain/CartMenu.java
@@ -28,6 +28,7 @@ public class CartMenu {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@Setter
 	private Cart cart;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -1,14 +1,22 @@
 package com.jaw.cart.ui;
 
-import com.jaw.auth.UserAuthentication;
-import com.jaw.cart.application.CartService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
+import com.jaw.auth.UserAuthentication;
+import com.jaw.cart.application.CartService;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/cart")
@@ -26,9 +34,9 @@ public class CartRestController {
 
 	@PostMapping("/cart-menus")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<CartResponseDTO> addMenu(@RequestBody CartMenuRequestDTO request,
-												   UserAuthentication authentication) {
-		CartResponseDTO cart = cartService.addCartMenu(authentication.getUserId(), request);
+	public ResponseEntity<CartMenuResponseDTO> addMenu(@RequestBody CartMenuRequestDTO request,
+													   UserAuthentication authentication) {
+		CartMenuResponseDTO cart = cartService.addCartMenu(authentication.getUserId(), request);
 		return ResponseEntity.created(URI.create("/api/cart"))
 			.body(cart);
 	}
@@ -50,12 +58,20 @@ public class CartRestController {
 		return ResponseEntity.ok(cartMenu);
 	}
 
+	@DeleteMapping("/cart-menus/{id}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<Void> deleteCartMenu(@PathVariable Long id,
+														  UserAuthentication authentication) {
+		cartService.deleteCartMenu(authentication.getUserId(), id);
+		return ResponseEntity.noContent().build();
+	}
+
 	@DeleteMapping("/cart-menus")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<CartResponseDTO> deleteCartMenus(@RequestBody CartMenuDeleteRequest request,
+	public ResponseEntity<Void> deleteCartMenus(@RequestBody CartMenuDeleteRequest request,
 														   UserAuthentication authentication) {
-		CartResponseDTO cart = cartService.deleteCartMenus(authentication.getUserId(), request.getCartMenuIds());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(cart);
+		cartService.deleteCartMenus(authentication.getUserId(), request.getCartMenuIds());
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/order")

--- a/src/main/java/com/jaw/cart/ui/CartRestController.java
+++ b/src/main/java/com/jaw/cart/ui/CartRestController.java
@@ -61,7 +61,7 @@ public class CartRestController {
 	@DeleteMapping("/cart-menus/{id}")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<Void> deleteCartMenu(@PathVariable Long id,
-														  UserAuthentication authentication) {
+											   UserAuthentication authentication) {
 		cartService.deleteCartMenu(authentication.getUserId(), id);
 		return ResponseEntity.noContent().build();
 	}
@@ -69,8 +69,15 @@ public class CartRestController {
 	@DeleteMapping("/cart-menus")
 	@PreAuthorize("isAuthenticated()")
 	public ResponseEntity<Void> deleteCartMenus(@RequestBody CartMenuDeleteRequest request,
-														   UserAuthentication authentication) {
+												UserAuthentication authentication) {
 		cartService.deleteCartMenus(authentication.getUserId(), request.getCartMenuIds());
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/cart-menus/all")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<Void> deleteAllCartMenus(UserAuthentication authentication) {
+		cartService.deleteAllCartMenus(authentication.getUserId());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/jaw/order/domain/OrderMenu.java
+++ b/src/main/java/com/jaw/order/domain/OrderMenu.java
@@ -1,5 +1,7 @@
 package com.jaw.order.domain;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -34,8 +36,11 @@ public class OrderMenu {
 	@Column(nullable = false)
 	private Long quantity;
 
+	private BigDecimal price;
+
 	public OrderMenu(Menu menu, Long quantity) {
 		this.menu = menu;
 		this.quantity = quantity;
+		this.price = menu.getPrice().multiply(BigDecimal.valueOf(quantity));
 	}
 }

--- a/src/main/java/com/jaw/order/ui/OrderMenuResponseDTO.java
+++ b/src/main/java/com/jaw/order/ui/OrderMenuResponseDTO.java
@@ -1,5 +1,7 @@
 package com.jaw.order.ui;
 
+import java.math.BigDecimal;
+
 import com.jaw.menu.ui.MenuResponseDTO;
 import com.jaw.order.domain.OrderMenu;
 
@@ -10,9 +12,11 @@ public class OrderMenuResponseDTO {
 
 	private final MenuResponseDTO menu;
 	private final Long quantity;
+	private final BigDecimal price;
 
 	public OrderMenuResponseDTO(OrderMenu orderMenu) {
 		this.menu = new MenuResponseDTO(orderMenu.getMenu());
 		this.quantity = orderMenu.getQuantity();
+		this.price = orderMenu.getPrice();
 	}
 }

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -207,10 +207,11 @@ class CartServiceTest {
 			new CartMenuRequestDTO(menu.getId(), 1L));
 		CartMenuUpdateDTO updateRequest = new CartMenuUpdateDTO(2L);
 
-		CartMenuResponseDTO updatedCartMenu = cartService.changeCartMenuQuantity(member.getId(), cartMenu.getId(),
-			updateRequest);
+		CartMenuResponseDTO updatedCartMenu =
+			cartService.changeCartMenuQuantity(member.getId(), cartMenu.getId(), updateRequest);
 
 		assertThat(updatedCartMenu.getQuantity()).isEqualTo(2L);
+		assertThat(updatedCartMenu.getPrice()).isEqualTo(BigDecimal.valueOf(2_000L));
 	}
 
 	@DisplayName("장바구니에 담긴 메뉴가 없다면, 메뉴의 수량을 변경할 수 없다.")

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -98,7 +98,7 @@ class CartServiceTest {
 		assertThat(cartMenus).isEmpty();
 	}
 
-	@DisplayName("장바구니에 담긴 모든 메뉴를 삭제한다.")
+	@DisplayName("장바구니에 담긴 메뉴들을 삭제한다.")
 	@Test
 	void deleteCartMenus() {
 		Member member = memberRepository.save(member());
@@ -111,6 +111,25 @@ class CartServiceTest {
 			.orElseThrow(IllegalArgumentException::new);
 
 		cartService.deleteCartMenus(member.getId(), Arrays.asList(1L, 2L));
+
+		List<CartMenu> cartMenus = cartMenuRepository.findAllByCart(cart);
+
+		assertThat(cartMenus).isEmpty();
+	}
+
+	@DisplayName("장바구니에 담긴 모든 메뉴를 삭제한다.")
+	@Test
+	void deleteAllCartMenus() {
+		Member member = memberRepository.save(member());
+		Menu vanillaFlatWhite = menuRepository.save(menu("바닐라 플랫 화이트", 5_900L));
+		Menu icedCaffeMocha = menuRepository.save(menu("아이스 카페 모카", 5_500L));
+		cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(vanillaFlatWhite.getId(), 1));
+		cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(icedCaffeMocha.getId(), 2));
+
+		Cart cart = cartRepository.findByMemberId(member.getId())
+			.orElseThrow(IllegalArgumentException::new);
+
+		cartService.deleteAllCartMenus(member.getId());
 
 		List<CartMenu> cartMenus = cartMenuRepository.findAllByCart(cart);
 
@@ -156,10 +175,10 @@ class CartServiceTest {
 		Menu mixCoffee = menuRepository.save(menu("믹스 커피", 1_000L));
 		Menu americano = menuRepository.save(menu("아메리카노", 2_000L));
 
-		Long mixCoffeeMenuId = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(mixCoffee.getId(), 1))
-			.getId();
-		Long americanoMenuId = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(americano.getId(), 1))
-			.getId();
+		Long mixCoffeeMenuId = cartService.addCartMenu(member.getId(),
+				new CartMenuRequestDTO(mixCoffee.getId(), 1)).getId();
+		Long americanoMenuId = cartService.addCartMenu(member.getId(),
+				new CartMenuRequestDTO(americano.getId(), 1)).getId();
 
 		CartMenuOrderRequestDTO orderRequest = new CartMenuOrderRequestDTO();
 		orderRequest.setCartMenuIds(List.of(mixCoffeeMenuId, americanoMenuId));

--- a/src/test/java/com/jaw/cart/application/CartServiceTest.java
+++ b/src/test/java/com/jaw/cart/application/CartServiceTest.java
@@ -1,26 +1,31 @@
 package com.jaw.cart.application;
 
+import static com.jaw.Fixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.jaw.cart.domain.Cart;
 import com.jaw.cart.domain.CartMenu;
-import com.jaw.cart.ui.*;
+import com.jaw.cart.ui.CartMenuOrderRequestDTO;
+import com.jaw.cart.ui.CartMenuOrderResponseDTO;
+import com.jaw.cart.ui.CartMenuRequestDTO;
+import com.jaw.cart.ui.CartMenuResponseDTO;
+import com.jaw.cart.ui.CartMenuUpdateDTO;
+import com.jaw.cart.ui.CartResponseDTO;
 import com.jaw.member.application.InMemoryMemberRepository;
 import com.jaw.member.domain.Member;
 import com.jaw.menu.application.InMemoryMenuRepository;
 import com.jaw.menu.domain.Menu;
 import com.jaw.order.application.InMemoryOrderRepository;
 import com.jaw.order.ui.OrderMenuResponseDTO;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
-
-import static com.jaw.Fixtures.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CartServiceTest {
 
@@ -38,7 +43,8 @@ class CartServiceTest {
 		menuRepository = new InMemoryMenuRepository();
 		memberRepository = new InMemoryMemberRepository();
 		orderRepository = new InMemoryOrderRepository();
-		cartService = new CartService(cartRepository, cartMenuRepository, menuRepository, memberRepository, orderRepository);
+		cartService = new CartService(cartRepository, cartMenuRepository, menuRepository, memberRepository,
+			orderRepository);
 	}
 
 	@AfterEach
@@ -76,6 +82,23 @@ class CartServiceTest {
 	}
 
 	@DisplayName("장바구니에 담긴 메뉴를 삭제한다.")
+	@Test
+	void deleteCartMenu() {
+		Member member = memberRepository.save(member());
+		Menu vanillaFlatWhite = menuRepository.save(menu("바닐라 플랫 화이트", 5_900L));
+		cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(vanillaFlatWhite.getId(), 1));
+
+		Cart cart = cartRepository.findByMemberId(member.getId())
+			.orElseThrow(IllegalArgumentException::new);
+
+		cartService.deleteCartMenu(member.getId(), 1L);
+
+		List<CartMenu> cartMenus = cartMenuRepository.findAllByCart(cart);
+
+		assertThat(cartMenus).isEmpty();
+	}
+
+	@DisplayName("장바구니에 담긴 모든 메뉴를 삭제한다.")
 	@Test
 	void deleteCartMenus() {
 		Member member = memberRepository.save(member());
@@ -133,8 +156,10 @@ class CartServiceTest {
 		Menu mixCoffee = menuRepository.save(menu("믹스 커피", 1_000L));
 		Menu americano = menuRepository.save(menu("아메리카노", 2_000L));
 
-		Long mixCoffeeMenuId = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(mixCoffee.getId(), 1)).getId();
-		Long americanoMenuId = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(americano.getId(), 1)).getId();
+		Long mixCoffeeMenuId = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(mixCoffee.getId(), 1))
+			.getId();
+		Long americanoMenuId = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(americano.getId(), 1))
+			.getId();
 
 		CartMenuOrderRequestDTO orderRequest = new CartMenuOrderRequestDTO();
 		orderRequest.setCartMenuIds(List.of(mixCoffeeMenuId, americanoMenuId));
@@ -151,7 +176,7 @@ class CartServiceTest {
 		Member member = memberRepository.save(member());
 		cartRepository.save(new Cart(member));
 		Menu menu = menuRepository.save(menu("아메리카노", 1_000L));
-		CartResponseDTO cartMenu = cartService.addCartMenu(member.getId(),
+		CartMenuResponseDTO cartMenu = cartService.addCartMenu(member.getId(),
 			new CartMenuRequestDTO(menu.getId(), 2L));
 
 		CartMenuResponseDTO foundCartMenu = cartService.findCartMenuById(member.getId(), cartMenu.getId());
@@ -178,10 +203,12 @@ class CartServiceTest {
 	void changeCartMenuQuantity() {
 		Member member = memberRepository.save(member());
 		Menu menu = menuRepository.save(menu("아메리카노", 1_000L));
-		CartResponseDTO cartMenu = cartService.addCartMenu(member.getId(), new CartMenuRequestDTO(menu.getId(), 1L));
+		CartMenuResponseDTO cartMenu = cartService.addCartMenu(member.getId(),
+			new CartMenuRequestDTO(menu.getId(), 1L));
 		CartMenuUpdateDTO updateRequest = new CartMenuUpdateDTO(2L);
 
-		CartMenuResponseDTO updatedCartMenu = cartService.changeCartMenuQuantity(member.getId(), cartMenu.getId(), updateRequest);
+		CartMenuResponseDTO updatedCartMenu = cartService.changeCartMenuQuantity(member.getId(), cartMenu.getId(),
+			updateRequest);
 
 		assertThat(updatedCartMenu.getQuantity()).isEqualTo(2L);
 	}
@@ -192,8 +219,7 @@ class CartServiceTest {
 		Member member = memberRepository.save(member());
 		Member other = memberRepository.save(other());
 		Menu menu = menuRepository.save(menu("아메리카노", 1_000L));
-		CartResponseDTO cartMenu = cartService.addCartMenu(other.getId(),
-			new CartMenuRequestDTO(menu.getId(), 1L));
+		CartMenuResponseDTO cartMenu = cartService.addCartMenu(other.getId(), new CartMenuRequestDTO(menu.getId(), 1L));
 		CartMenuUpdateDTO updateRequest = new CartMenuUpdateDTO(2L);
 
 		assertThatThrownBy(() -> cartService.changeCartMenuQuantity(member.getId(), cartMenu.getId(), updateRequest))

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -1,13 +1,13 @@
 package com.jaw.cart.ui;
 
-import com.jaw.cart.application.CartService;
-import com.jaw.cart.domain.Cart;
-import com.jaw.cart.domain.CartMenu;
-import com.jaw.member.application.AuthenticationService;
-import com.jaw.member.domain.Member;
-import com.jaw.menu.domain.Menu;
-import com.jaw.order.domain.Order;
-import com.jaw.order.domain.OrderMenu;
+import static com.jaw.Fixtures.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,14 +17,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static com.jaw.Fixtures.*;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.jaw.cart.application.CartService;
+import com.jaw.cart.domain.Cart;
+import com.jaw.cart.domain.CartMenu;
+import com.jaw.member.application.AuthenticationService;
+import com.jaw.member.domain.Member;
+import com.jaw.menu.domain.Menu;
+import com.jaw.order.domain.Order;
+import com.jaw.order.domain.OrderMenu;
 
 @WebMvcTest(CartRestController.class)
 class CartRestControllerTest {
@@ -70,8 +70,7 @@ class CartRestControllerTest {
 				.header("Authorization", "Bearer " + VALID_TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(OBJECT_MAPPER.writeValueAsString(new CartMenuDeleteRequest(Arrays.asList(1L, 2L)))))
-			.andExpect(status().isNoContent())
-			.andExpect(jsonPath("$.cartMenus").isEmpty());
+			.andExpect(status().isNoContent());
 	}
 
 	@DisplayName("장바구니에 메뉴를 추가한다.")
@@ -79,19 +78,18 @@ class CartRestControllerTest {
 	void addMenu() throws Exception {
 		Menu americano = menu("아메리카노", 1_000L);
 		Cart cart = new Cart(member());
-
 		CartMenu cartMenu = new CartMenu(cart, americano, 1L);
 		cart.addMenu(cartMenu);
 
 		given(cartService.addCartMenu(any(Long.class), any(CartMenuRequestDTO.class)))
-			.willReturn(new CartResponseDTO(cart));
+			.willReturn(new CartMenuResponseDTO(cartMenu));
 
 		mvc.perform(post("/api/cart/cart-menus")
 				.header("Authorization", "Bearer " + VALID_TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(OBJECT_MAPPER.writeValueAsString(new CartMenuRequestDTO(americano.getId(), 1L))))
 			.andExpect(status().isCreated())
-			.andExpect(content().json(OBJECT_MAPPER.writeValueAsString(new CartResponseDTO(cart))));
+			.andExpect(content().json(OBJECT_MAPPER.writeValueAsString(new CartMenuResponseDTO(cartMenu))));
 	}
 
 	@DisplayName("장바구니에 담긴 메뉴를 주문한다.")

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -56,7 +56,7 @@ class CartRestControllerTest {
 			.andExpect(content().json(OBJECT_MAPPER.writeValueAsString(cart)));
 	}
 
-	@DisplayName("장바구니에 담긴 메뉴를 삭제한다.")
+	@DisplayName("장바구니에 담긴 메뉴들을 삭제한다.")
 	@Test
 	void deleteCartMenus() throws Exception {
 		CartResponseDTO cart = new CartResponseDTO(new Cart(member()));
@@ -85,6 +85,20 @@ class CartRestControllerTest {
 			.andExpect(status().isNoContent());
 
 		verify(cartService).deleteCartMenu(1L, 1L);
+	}
+
+	@DisplayName("장바구니에 담긴 모든 메뉴를 삭제한다.")
+	@Test
+	void deleteAllCartMenus() throws Exception {
+		given(authenticationService.parseToken(VALID_TOKEN)).willReturn(1L);
+
+		willDoNothing().given(cartService).deleteAllCartMenus(1L);
+
+		mvc.perform(delete("/api/cart/cart-menus/all")
+				.header("Authorization", "Bearer " + VALID_TOKEN))
+			.andExpect(status().isNoContent());
+
+		verify(cartService).deleteAllCartMenus(1L);
 	}
 
 	@DisplayName("장바구니에 메뉴를 추가한다.")

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -73,6 +73,20 @@ class CartRestControllerTest {
 			.andExpect(status().isNoContent());
 	}
 
+	@DisplayName("장바구니에 담긴 메뉴를 삭제한다.")
+	@Test
+	void deleteCartMenu() throws Exception {
+		given(authenticationService.parseToken(VALID_TOKEN)).willReturn(1L);
+
+		willDoNothing().given(cartService).deleteCartMenu(1L, 1L);
+
+		mvc.perform(delete("/api/cart/cart-menus/1")
+				.header("Authorization", "Bearer " + VALID_TOKEN))
+			.andExpect(status().isNoContent());
+
+		verify(cartService).deleteCartMenu(1L, 1L);
+	}
+
 	@DisplayName("장바구니에 메뉴를 추가한다.")
 	@Test
 	void addMenu() throws Exception {

--- a/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
+++ b/src/test/java/com/jaw/cart/ui/CartRestControllerTest.java
@@ -142,13 +142,16 @@ class CartRestControllerTest {
 		Cart cart = new Cart(member);
 		Menu menu = menu("아메리카노", 1_000L);
 
+		CartMenuResponseDTO expected = new CartMenuResponseDTO(new CartMenu(cart, menu, 2L));
+
 		given(cartService.changeCartMenuQuantity(any(Long.class), any(Long.class), any(CartMenuUpdateDTO.class)))
-			.willReturn(new CartMenuResponseDTO(new CartMenu(cart, menu, 1L)));
+			.willReturn(expected);
 
 		mvc.perform(patch("/api/cart/cart-menus/{id}", 1L)
 				.header("Authorization", "Bearer " + VALID_TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(OBJECT_MAPPER.writeValueAsString(new CartMenuUpdateDTO(2L))))
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andExpect(content().json(OBJECT_MAPPER.writeValueAsString(expected)));
 	}
 }


### PR DESCRIPTION
#### 장바구니 메뉴 엔티티 업데이트
- 장바구니 메뉴의 수량 변경 시, 금액도 수량에 따라 계산되도록 수정 (+ 주문 메뉴 엔티티에도 금액 필드 추가)
  
#### 장바구니 메뉴 API 목록 업데이트
  * `DELETE` `/api/cart/cart-menus/all` - 장바구니에 담긴 모든 메뉴 삭제
  * `DELETE` `/api/cart/cart-menus/{id}` - 장바구니에 담긴 단일 메뉴 삭제
  * `DELETE` `/api/cart/cart-menus` - 장바구니에 담긴 하나 이상의 메뉴를 삭제